### PR TITLE
Properly handle Base64-encoded attributes

### DIFF
--- a/src/main/java/org/lsc/plugins/connectors/executable/AbstractExecutableLdifService.java
+++ b/src/main/java/org/lsc/plugins/connectors/executable/AbstractExecutableLdifService.java
@@ -252,7 +252,7 @@ public abstract class AbstractExecutableLdifService implements IService {
 				String attributeId = attribute.getId().toLowerCase();
 				HashSet<Object> values = new HashSet<Object>();
 				for (Value value: attribute) {
-					values.add(value.toString());
+					values.add(value.getString());
 				}
 				bean.setDataset(attributeId, values);
 			}

--- a/src/test/java/org/lsc/plugins/connectors/executable/AbstractExecutableLdifServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/executable/AbstractExecutableLdifServiceTest.java
@@ -64,7 +64,8 @@ public class AbstractExecutableLdifServiceTest extends TestCase {
 				+ " main\n"
 				+ "singleAttribute: singleValue\n"
 				+ "multiAttribute: firstValue\n"
-				+ "multiAttribute: secondValue\n";
+				+ "multiAttribute: secondValue\n"
+				+ "encodedAttribute:: 5rGJ6K+t\n";
 		Collection<IBean> entries = executableLdifService.fromLdif(ldif);
 		
 		assertEquals(1, entries.size());
@@ -78,6 +79,8 @@ public class AbstractExecutableLdifServiceTest extends TestCase {
 		String[] multiValues = { "firstValue", "secondValue" } ;
 		HashSet<String> multiValuesSet = new HashSet<String>(Arrays.asList(multiValues));
 		assertEquals(multiValuesSet, entry.getDatasetById("multiAttribute"));
+		assertEquals("\u6C49\u8BED", entry.getDatasetFirstValueById("encodedAttribute"));
+
 	}
 	
 	private class TestExecutableLdifService extends AbstractExecutableLdifService {


### PR DESCRIPTION
Currently, if I use ExecutableLdifSourceService with a LDIF that contains base64-encoded fields, the attributes will show up incorrectly in LSC:

(actual value: `Cécile`)

ldif:
```
givenName:: Q8OpY2lsZQ==
```

in LSC the value appears, literaly, as :

```
0x43 0xC3 0xA9 0x63 0x69 0x6C 0x65
```

This MR fixes the conversion from o.a.d.api.ldap.model.entry.Value to java.lang.String so that Values that were decoded from Base64 no longer appear as a string of hex codes.

:warning:  possible regressions: pure binary data (jpegPhoto) that appears in a LDIF file will also be exposed to LSC as pure binary data from now on